### PR TITLE
Add a script that merges old and new data, also, MAKEFILE!

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/arpa20220125.iml
+++ b/.idea/arpa20220125.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="Pipenv (arpa20220125)" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/arpa20220125.iml" filepath="$PROJECT_DIR$/.idea/arpa20220125.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ all: analysis/output_data/output.csv  ## Download source data and run R analysis
 .PHONY: clean
 clean: clean/source_data clean/output_data  ## Clean files
 
+.PHONY: merge_old_and_new_data
+merge_old_and_new_data: analysis/output_data/q1_data_with_303_vetted_info.csv
+
 .PHONY: help
 help:  ## Display this help
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z\%\\.\/_-]+:.*?##/ { printf "\033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
@@ -27,6 +30,9 @@ analysis/output_data/output.csv: analysis/source_data/input.csv  ## Run R analys
 	@echo "Running R analysis"
 	Rscript analysis/analysis.R
 
+##@ Merge old and new datasets
+analysis/output_data/q1_data_with_303_vetted_info.csv:
+	$(PYENV) python analysis/merge_two_datasets_with_unique_id.py
 
 ##@ Source files
 analysis/source_data/input.csv:  ## Download a test input csv to source data directory

--- a/analysis/classfications
+++ b/analysis/classfications
@@ -1,5 +1,6 @@
-list_le = "police","PD","gun","law enforcement","public safety","crime","criminal","body cameras","tasers","armor","sheriff","officer"
+list_le = ["police","PD","gun","law enforcement","public safety","crime","criminal","body cameras","tasers","armor","sheriff","officer"]
 
-list_court = "court","public defenders","prosecutors","juvenile court","juvenile justice"
+list_court = ["court","public defenders","prosecutors","juvenile court","juvenile justice"]
 
-list_correction = "jail","prison","correction","incarcerated","inmate","guards","custody"
+list_correction = ["jail","prison","correction","incarcerated","inmate","guards","custody"]
+]

--- a/analysis/create_id.ipynb
+++ b/analysis/create_id.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": 86,
-   "id": "subjective-broadway",
+   "id": "decreased-chocolate",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -13,7 +13,7 @@
   {
    "cell_type": "code",
    "execution_count": 87,
-   "id": "silent-pharmaceutical",
+   "id": "invalid-possibility",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -27,7 +27,7 @@
   {
    "cell_type": "code",
    "execution_count": 88,
-   "id": "every-council",
+   "id": "measured-illinois",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -43,8 +43,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 89,
-   "id": "domestic-syntax",
+   "execution_count": 104,
+   "id": "average-bench",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -59,13 +59,16 @@
     "    id_joined = pd.merge(df_new_with_id, df_old_vetted_short, on=\"tmp_id\")[\"tmp_id\"].to_list()\n",
     "    df_did_not_merge = df_old_vetted[~df_old_vetted[\"tmp_id\"].isin(id_joined)]\n",
     "    \n",
-    "    return df_merge, df_did_not_merge"
+    "    id_joined_all = pd.merge(df_new_with_id, df_old_with_id, on=\"tmp_id\")[\"tmp_id\"].to_list()\n",
+    "    df_did_not_merge_all = df_old_with_id[~df_old_with_id[\"tmp_id\"].isin(id_joined_all)]\n",
+    "\n",
+    "    return df_merge, df_did_not_merge, df_did_not_merge_all"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 90,
-   "id": "alert-output",
+   "id": "returning-ceremony",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -77,15 +80,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "future-helena",
+   "id": "urban-dietary",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "code",
-   "execution_count": 92,
-   "id": "fitted-station",
+   "execution_count": 105,
+   "id": "violent-european",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -96,7 +99,7 @@
     "# get unique id by combining columns in the two datasets\n",
     "df_old_with_id, df_new_with_id = get_unique_ids(df_old, df_new)\n",
     "# let's do some merging!\n",
-    "df_merge, df_did_not_merge = merge(df_old_with_id, df_new_with_id)\n",
+    "df_merge, df_did_not_merge, df_did_not_merge_all = merge(df_old_with_id, df_new_with_id)\n",
     "\n",
     "# export\n",
     "df_merge_path = \"output_data/q1_data_with_303_vetted_info.csv\"\n",
@@ -106,8 +109,55 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 110,
+   "id": "central-meter",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_did_not_merge_all.to_csv(\"output_data/not_merging.csv\", index=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 109,
+   "id": "bridal-fireplace",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.03772282921219092"
+      ]
+     },
+     "execution_count": 109,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "1640/len(df_new)"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": null,
-   "id": "hungry-casting",
+   "id": "increasing-liberal",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "listed-recipient",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "recorded-carpet",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/analysis/create_id.ipynb
+++ b/analysis/create_id.ipynb
@@ -1,0 +1,137 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 86,
+   "id": "subjective-broadway",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 87,
+   "id": "silent-pharmaceutical",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def read_data(filenames):    \n",
+    "    df_old = pd.read_csv(filenames[0])\n",
+    "    df_new = pd.read_csv(filenames[1])\n",
+    "    \n",
+    "    return df_old, df_new"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 88,
+   "id": "every-council",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_unique_ids(df_old, df_new):\n",
+    "    df_old[\"tmp_id\"] = df_old[\"Recipient Name\"] +\\\n",
+    "    \"_\" + df_old[\"Project Name\"]\n",
+    "    \n",
+    "    df_new[\"tmp_id\"] = df_new[\"Recipient Name\"] +\\\n",
+    "    \"_\" + df_new[\"Project Name\"]\n",
+    "    \n",
+    "    return df_old, df_new"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 89,
+   "id": "domestic-syntax",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def merge(df_old_with_id, df_new_with_id):\n",
+    "    df_old_vetted = df_old_with_id[~df_old_with_id[\"vet\"].isnull()]\n",
+    "    df_old_vetted_short = df_old_vetted[[\"tmp_id\", 'law_enforcement', 'court', 'corrections', 'cj_related','vet', 'reporter']]\n",
+    "    \n",
+    "    # merge the new dataset with rows from the old one that we looked at.\n",
+    "    df_merge = pd.merge(df_new, df_old_vetted_short, on=\"tmp_id\", how=\"left\")\n",
+    "    \n",
+    "    # there are 33 rows that did not merge. Will export and investigate more.\n",
+    "    id_joined = pd.merge(df_new_with_id, df_old_vetted_short, on=\"tmp_id\")[\"tmp_id\"].to_list()\n",
+    "    df_did_not_merge = df_old_vetted[~df_old_vetted[\"tmp_id\"].isin(id_joined)]\n",
+    "    \n",
+    "    return df_merge, df_did_not_merge"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 90,
+   "id": "alert-output",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def export(df_merge, df_did_not_merge, df_merge_path, df_did_not_merge_path):\n",
+    "    df_merge.to_csv(df_merge_path, index=False)\n",
+    "    df_did_not_merge.to_csv(df_did_not_merge_path, index=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "future-helena",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 92,
+   "id": "fitted-station",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filenames = [\"source_data/cj_related/cj_related_old.csv\", \"source_data/cj_related/cj_related_new.csv\"]\n",
+    "\n",
+    "# read in two datasets\n",
+    "df_old, df_new = read_data(filenames)\n",
+    "# get unique id by combining columns in the two datasets\n",
+    "df_old_with_id, df_new_with_id = get_unique_ids(df_old, df_new)\n",
+    "# let's do some merging!\n",
+    "df_merge, df_did_not_merge = merge(df_old_with_id, df_new_with_id)\n",
+    "\n",
+    "# export\n",
+    "df_merge_path = \"output_data/q1_data_with_303_vetted_info.csv\"\n",
+    "df_did_not_merge_path = \"output_data/missing_from_q1.csv\"\n",
+    "export(df_merge, df_did_not_merge, df_merge_path, df_did_not_merge_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "hungry-casting",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/analysis/merge_two_datasets_with_unique_id.py
+++ b/analysis/merge_two_datasets_with_unique_id.py
@@ -1,0 +1,60 @@
+import pandas as pd
+
+# Ana and Weihua vetted 336 cj-related projects from the 2021 dataset
+# After getting the Q1 2022 dataset, we did not want to lose that progress and start over
+# So we created this script that creates unique IDs for cj-related projects, and merge thd vetted data
+# from the old dataset to the new one.
+
+# Ideally you'll only need to run this script once new data come in
+# We did run into one problem: some projects from the old dataset do not exist in the new one.
+# Why? Gotta report that out!
+
+def read_data(filenames):
+    df_old = pd.read_csv(filenames[0])
+    df_new = pd.read_csv(filenames[1])
+
+    return df_old, df_new
+
+
+def get_unique_ids(df_old, df_new):
+    df_old["tmp_id"] = df_old["Recipient Name"] + \
+                       "_" + df_old["Project Name"]
+
+    df_new["tmp_id"] = df_new["Recipient Name"] + \
+                       "_" + df_new["Project Name"]
+
+    return df_old, df_new
+
+
+def merge(df_old_with_id, df_new_with_id):
+    df_old_vetted = df_old_with_id[~df_old_with_id["vet"].isnull()]
+    df_old_vetted_short = df_old_vetted[
+        ["tmp_id", 'law_enforcement', 'court', 'corrections', 'cj_related', 'vet', 'reporter']]
+
+    # merge the new dataset with rows from the old one that we looked at.
+    df_merge = pd.merge(df_new, df_old_vetted_short, on="tmp_id", how="left")
+
+    # there are 33 rows that did not merge. Will export and investigate more.
+    id_joined = pd.merge(df_new_with_id, df_old_vetted_short, on="tmp_id")["tmp_id"].to_list()
+    df_did_not_merge = df_old_vetted[~df_old_vetted["tmp_id"].isin(id_joined)]
+
+    return df_merge, df_did_not_merge
+
+def export(df_merge, df_did_not_merge, df_merge_path, df_did_not_merge_path):
+    df_merge.to_csv(df_merge_path, index=False)
+    df_did_not_merge.to_csv(df_did_not_merge_path, index=False)
+
+if __name__ == "__main__":
+    filenames = ["analysis/source_data/cj_related/cj_related_old.csv", "analysis/source_data/cj_related/cj_related_new.csv"]
+
+    # read in two datasets
+    df_old, df_new = read_data(filenames)
+    # get unique id by combining columns in the two datasets
+    df_old_with_id, df_new_with_id = get_unique_ids(df_old, df_new)
+    # let's do some merging!
+    df_merge, df_did_not_merge = merge(df_old_with_id, df_new_with_id)
+
+    # export
+    df_merge_path = "analysis/output_data/q1_data_with_303_vetted_info.csv"
+    df_did_not_merge_path = "analysis/output_data/missing_from_q1.csv"
+    export(df_merge, df_did_not_merge, df_merge_path, df_did_not_merge_path)

--- a/analysis/output_data/missing_from_q1.csv
+++ b/analysis/output_data/missing_from_q1.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:19cfb1216252da06cbd6b7e3796ca377d76912ac9bb0e085671dfa0ae70ec6fc
+size 35045

--- a/analysis/output_data/not_merging.csv
+++ b/analysis/output_data/not_merging.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a34f9a09b31cb1159771ce5ef186ec0253b7583636183cded93eda7347c1fcd
+size 1220962

--- a/analysis/output_data/q1_data_with_303_vetted_info.csv
+++ b/analysis/output_data/q1_data_with_303_vetted_info.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2938395c8dd502b5ec8a1aa0e2c849ddd4b2c71358f15081599aa66d47dac615
+size 32010203

--- a/analysis/project-level-analysis.ipynb
+++ b/analysis/project-level-analysis.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": 73,
-   "id": "metropolitan-sewing",
+   "id": "stylish-infrastructure",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -18,7 +18,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "center-table",
+   "id": "formed-leonard",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -29,7 +29,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "transparent-samba",
+   "id": "union-madison",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -39,7 +39,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "indoor-inside",
+   "id": "paperback-surveillance",
    "metadata": {},
    "source": [
     "### law enforcement\n",
@@ -55,7 +55,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "numerous-cooper",
+   "id": "consolidated-douglas",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -69,7 +69,7 @@
   {
    "cell_type": "code",
    "execution_count": 30,
-   "id": "valuable-headline",
+   "id": "blessed-citation",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -81,7 +81,7 @@
   {
    "cell_type": "code",
    "execution_count": 35,
-   "id": "final-algebra",
+   "id": "ordered-impression",
    "metadata": {},
    "outputs": [
     {
@@ -112,7 +112,7 @@
   {
    "cell_type": "code",
    "execution_count": 39,
-   "id": "liquid-prayer",
+   "id": "reliable-planet",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -126,7 +126,7 @@
   {
    "cell_type": "code",
    "execution_count": 40,
-   "id": "comprehensive-printing",
+   "id": "minute-coach",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -136,7 +136,7 @@
   {
    "cell_type": "code",
    "execution_count": 80,
-   "id": "knowing-riverside",
+   "id": "refined-strategy",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -146,7 +146,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "supposed-childhood",
+   "id": "demanding-sally",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -156,7 +156,7 @@
   {
    "cell_type": "code",
    "execution_count": 48,
-   "id": "historic-boards",
+   "id": "growing-vietnamese",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -171,7 +171,7 @@
   {
    "cell_type": "code",
    "execution_count": 49,
-   "id": "persistent-knitting",
+   "id": "ultimate-terrorist",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -186,7 +186,7 @@
   {
    "cell_type": "code",
    "execution_count": 51,
-   "id": "demographic-shoot",
+   "id": "strong-hebrew",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -196,7 +196,7 @@
   {
    "cell_type": "code",
    "execution_count": 55,
-   "id": "ancient-vatican",
+   "id": "acceptable-farming",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -206,7 +206,7 @@
   {
    "cell_type": "code",
    "execution_count": 57,
-   "id": "charming-architecture",
+   "id": "atlantic-pittsburgh",
    "metadata": {},
    "outputs": [
     {
@@ -681,7 +681,7 @@
   {
    "cell_type": "code",
    "execution_count": 59,
-   "id": "rising-anger",
+   "id": "amended-greene",
    "metadata": {},
    "outputs": [
     {
@@ -702,7 +702,7 @@
   {
    "cell_type": "code",
    "execution_count": 67,
-   "id": "cosmetic-stuff",
+   "id": "protecting-lithuania",
    "metadata": {},
    "outputs": [
     {
@@ -723,7 +723,7 @@
   {
    "cell_type": "code",
    "execution_count": 68,
-   "id": "acquired-motorcycle",
+   "id": "headed-imagination",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -749,7 +749,7 @@
   {
    "cell_type": "code",
    "execution_count": 71,
-   "id": "afraid-colleague",
+   "id": "offensive-assault",
    "metadata": {},
    "outputs": [
     {
@@ -982,7 +982,7 @@
   {
    "cell_type": "code",
    "execution_count": 81,
-   "id": "liable-stage",
+   "id": "noble-mortgage",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -993,7 +993,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "strong-producer",
+   "id": "persistent-knife",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -1001,7 +1001,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "twenty-shopper",
+   "id": "characteristic-guidance",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -1009,7 +1009,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bizarre-college",
+   "id": "moved-drill",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -1017,7 +1017,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "forward-jewel",
+   "id": "packed-present",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -1025,7 +1025,7 @@
   {
    "cell_type": "code",
    "execution_count": 84,
-   "id": "early-gospel",
+   "id": "least-empty",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1070,7 +1070,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "anonymous-moscow",
+   "id": "fifth-stupid",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -1078,7 +1078,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "killing-pencil",
+   "id": "floating-editor",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
Ana and I vetted 336 CJ-related projects from the 2021 dataset. After getting the Q1 2022 dataset, we did not want to lose that progress and start over.

So we created this script that creates unique IDs for CJ-related projects, and merge the vetted data from the old dataset to the new one.

Ideally you'll only need to run this script once new data come in.

We did run into one problem: some projects from the old dataset do not exist in the new one.

Why? Gotta report that out!
